### PR TITLE
Implement char data type

### DIFF
--- a/assembly/poppyio.s
+++ b/assembly/poppyio.s
@@ -15,3 +15,17 @@ print_line:
     ldp     x1, x2, [sp], #16
     ldr     x0, [sp], #16
     ret
+print_char:
+    stp     lr, x0, [sp, #-16]!
+    stp     x1, x2, [sp, #-16]!
+
+    mov     x0, #1           // x0 is the file descriptor (1 for stdout)
+    mov     x2, #1           // x2 is the length of the string (always 1 for our case)
+    mov     x8, #64          // 64 is the syscall number for write
+    str     x1, [sp, #-16]!
+    mov     x1, sp           // set x1 to the top of the stack
+    add     sp, sp, #16      // pop the top value from the stack
+    svc     #0               // call the write syscall
+    ldp     x1, x2, [sp], #16
+    ldr     x0, [sp], #16
+    ret

--- a/c/include/lang/symbol.h
+++ b/c/include/lang/symbol.h
@@ -29,6 +29,8 @@ enum symbol {
         SYMBOL_ASSIGN,     // =
         SYMBOL_COMMA,      // ,
         SYMBOL_SEMICOLON,  // ;
+        SYMBOL_SQUOTE,     // '
+        SYMBOL_CHAR,
         SYMBOL_ELSE,
         SYMBOL_FOR,
         SYMBOL_HOP,
@@ -40,6 +42,7 @@ enum symbol {
         SYMBOL_WHILE,
         SYMBOL_IDENTIFIER,
         SYMBOL_CONSTANT,
+        SYMBOL_CHARLIT,
         SYMBOL_END,         // end of input
         // non-terminal symbols
         SYMBOL_PROGRAM,

--- a/c/include/lang/type.h
+++ b/c/include/lang/type.h
@@ -17,6 +17,7 @@ struct type {
 const struct type* const int_type();
 const struct type* const bool_type();
 const struct type* const void_type();
+const struct type* const char_type();
 const struct type* const function_type(const struct type *ret, const struct type *params[MAX_PARAM_COUNT], size_t params_len);
 const struct type* const return_type(const struct type *type);
 bool equals_type(const struct type *t1, const struct type *t2);

--- a/c/src/codegen/program.c
+++ b/c/src/codegen/program.c
@@ -259,6 +259,12 @@ char *generate_from_tree(struct parse_tree *tree, struct MAP(string, function) *
                         return movi(REG_ARITH_RESULT, imm);
                 }
 
+                if (first == SYMBOL_SQUOTE){
+                        char *data = tree->children->head->next->data->data.value;
+                        long long imm = data[0];
+                        return movi(REG_ARITH_RESULT, imm);
+                }
+
                 if (first == SYMBOL_IDENTIFIER){
                         char *id = tree->children->head->data->data.value;
 

--- a/c/src/lang/builtin.c
+++ b/c/src/lang/builtin.c
@@ -21,6 +21,19 @@ char *evaluate_print_num(char **args){
         );
 }
 
+char *evaluate_print_char(char **args){
+        char *bl = (char*) malloc(14 * sizeof(char));
+        strcpy(bl, "bl print_char");
+
+        return concat(5,
+                args[0],
+                mov(REG_1, REG_ARITH_RESULT),
+                push(REG_LR),
+                bl,
+                pop(REG_LR)
+        );
+}
+
 char *evaluate_print_line(char **args){
         char *bl = (char*) malloc(14 * sizeof(char));
         strcpy(bl, "bl print_line");
@@ -45,6 +58,10 @@ void append_io_builtins(struct LIST(builtin)* list){
         params[0] = int_type();
         struct builtin *print_num = new_builtin("print", function_type(print_ret, params, 1), evaluate_print_num);
         append_list(list, print_num, builtin);
+
+        params[0] = char_type();
+        struct builtin *print_char = new_builtin("printc", function_type(print_ret, params, 1), evaluate_print_char);
+        append_list(list, print_char, builtin);
 
         params[0] = NULL;
         struct builtin *print_line = new_builtin("println", function_type(print_ret, params, 0), evaluate_print_line);

--- a/c/src/lang/lexer.c
+++ b/c/src/lang/lexer.c
@@ -5,6 +5,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define NO_CHARLIT 0
+#define OPENED_CHARLIT 1
+#define UNCLOSED_CHARLIT 2
+
 #define MAX_TOKEN_LENGTH 128
 
 bool is_numeric(char c){
@@ -108,98 +112,118 @@ struct LIST(token)* lex(FILE *file){
         val[0] = 0;
         struct LIST(token) *list = (struct LIST(token)*) malloc(sizeof(struct LIST(token)));
         init_list(list);
+        int charlit_status = NO_CHARLIT;
 
         while (!feof(file)){
                 if (val[0] == 0){
                         val[0] = fgetc(file);
                 }
 
-                if (isspace(val[0])){
-                        val[0] = 0;
-                        continue;
-                }
-
                 struct lex_data data;
                 data.type = SYMBOL_NULL;
                 data.excess = 0;
 
-                switch (val[0]){
-                        case -1:
-                                data.type = SYMBOL_END;
-                                data.val_len = 0;
-                                break;
-                        case '(':
-                                data.type = SYMBOL_LPAREN;
-                                data.val_len = 1;
-                                break;
-                        case ')':
-                                data.type = SYMBOL_RPAREN;
-                                data.val_len = 1;
-                                break;
-                        case '{':
-                                data.type = SYMBOL_LBRACE;
-                                data.val_len = 1;
-                                break;
-                        case '}':
-                                data.type = SYMBOL_RBRACE;
-                                data.val_len = 1;
-                                break;
-                        case '*':
-                                data.type = SYMBOL_TIMES;
-                                data.val_len = 1;
-                                break;
-                        case '/':
-                                data.type = SYMBOL_DIVIDE;
-                                data.val_len = 1;
-                                break;
-                        case '%':
-                                data.type = SYMBOL_MOD;
-                                data.val_len = 1;
-                                break;
-                        case ',':
-                                data.type = SYMBOL_COMMA;
-                                data.val_len = 1;
-                                break;
-                        case ';':
-                                data.type = SYMBOL_SEMICOLON;
-                                data.val_len = 1;
-                                break;
-                        case '+':
-                                data = find_prefixed_type(file, '+', SYMBOL_PLUS, SYMBOL_INC, val);
-                                break;
-                        case '-':
-                                data = find_prefixed_type(file, '-', SYMBOL_MINUS, SYMBOL_DEC, val);
-                                break;
-                        case '&':
-                                data = find_prefixed_type(file, '&', SYMBOL_NULL, SYMBOL_AND, val);
-                                break;                        
-                        case '|':
-                                data = find_prefixed_type(file, '|', SYMBOL_NULL, SYMBOL_OR, val);
-                                break;   
-                        case '!':
-                                data = find_prefixed_type(file, '=', SYMBOL_NOT, SYMBOL_NE, val);
-                                break;      
-                        case '>':
-                                data = find_prefixed_type(file, '=', SYMBOL_GT, SYMBOL_GE, val);
-                                break;      
-                        case '<':
-                                data = find_prefixed_type(file, '=', SYMBOL_LT, SYMBOL_LE, val);
-                                break;
-                        case '=':
-                                data = find_prefixed_type(file, '=', SYMBOL_ASSIGN, SYMBOL_EQ, val);
-                                break; 
-                        default:
-                                if (is_alphabetic(val[0])){
-                                        data = find_alphanumeric_value(file, val);
-                                } else if (is_numeric(val[0])){
-                                        data = find_numeric_value(file, val);
-                                }
+                if (charlit_status == OPENED_CHARLIT){
+                        data.type = SYMBOL_CHARLIT;
+                        data.val_len = 1;
+                } else {
+                        if (isspace(val[0])){
+                                val[0] = 0;
+                                continue;
+                        }
+
+                        switch (val[0]){
+                                case -1:
+                                        data.type = SYMBOL_END;
+                                        data.val_len = 0;
+                                        break;
+                                case '(':
+                                        data.type = SYMBOL_LPAREN;
+                                        data.val_len = 1;
+                                        break;
+                                case ')':
+                                        data.type = SYMBOL_RPAREN;
+                                        data.val_len = 1;
+                                        break;
+                                case '{':
+                                        data.type = SYMBOL_LBRACE;
+                                        data.val_len = 1;
+                                        break;
+                                case '}':
+                                        data.type = SYMBOL_RBRACE;
+                                        data.val_len = 1;
+                                        break;
+                                case '*':
+                                        data.type = SYMBOL_TIMES;
+                                        data.val_len = 1;
+                                        break;
+                                case '/':
+                                        data.type = SYMBOL_DIVIDE;
+                                        data.val_len = 1;
+                                        break;
+                                case '%':
+                                        data.type = SYMBOL_MOD;
+                                        data.val_len = 1;
+                                        break;
+                                case ',':
+                                        data.type = SYMBOL_COMMA;
+                                        data.val_len = 1;
+                                        break;
+                                case ';':
+                                        data.type = SYMBOL_SEMICOLON;
+                                        data.val_len = 1;
+                                        break;
+                                case '\'':
+                                        data.type = SYMBOL_SQUOTE;
+                                        data.val_len = 1;
+                                        if (charlit_status == NO_CHARLIT){
+                                                charlit_status = OPENED_CHARLIT;
+                                        } else if (charlit_status == UNCLOSED_CHARLIT){
+                                                charlit_status = NO_CHARLIT;
+                                        }
+                                        break;
+                                case '+':
+                                        data = find_prefixed_type(file, '+', SYMBOL_PLUS, SYMBOL_INC, val);
+                                        break;
+                                case '-':
+                                        data = find_prefixed_type(file, '-', SYMBOL_MINUS, SYMBOL_DEC, val);
+                                        break;
+                                case '&':
+                                        data = find_prefixed_type(file, '&', SYMBOL_NULL, SYMBOL_AND, val);
+                                        break;                        
+                                case '|':
+                                        data = find_prefixed_type(file, '|', SYMBOL_NULL, SYMBOL_OR, val);
+                                        break;   
+                                case '!':
+                                        data = find_prefixed_type(file, '=', SYMBOL_NOT, SYMBOL_NE, val);
+                                        break;      
+                                case '>':
+                                        data = find_prefixed_type(file, '=', SYMBOL_GT, SYMBOL_GE, val);
+                                        break;      
+                                case '<':
+                                        data = find_prefixed_type(file, '=', SYMBOL_LT, SYMBOL_LE, val);
+                                        break;
+                                case '=':
+                                        data = find_prefixed_type(file, '=', SYMBOL_ASSIGN, SYMBOL_EQ, val);
+                                        break; 
+                                default:
+                                        if (is_alphabetic(val[0])){
+                                                data = find_alphanumeric_value(file, val);
+                                        } else if (is_numeric(val[0])){
+                                                data = find_numeric_value(file, val);
+                                        }
+                        }
+
                 }
 
-                if (data.type == SYMBOL_NULL){
+                if ((data.type == SYMBOL_NULL) || (charlit_status == UNCLOSED_CHARLIT)){
                         free_list(list, free_token, token);
                         free(list);
                         return NULL;
+                }
+
+                if ((charlit_status == OPENED_CHARLIT) && (data.type != SYMBOL_SQUOTE)){
+                        charlit_status = UNCLOSED_CHARLIT;
                 }
 
                 struct token *new_token = (struct token*) malloc(sizeof(struct token));
@@ -212,6 +236,12 @@ struct LIST(token)* lex(FILE *file){
 
                 val[0] = data.excess;
                 data.excess = 0;
+        }
+
+        if (charlit_status != NO_CHARLIT){
+                free_list(list, free_token, token);
+                free(list);
+                return NULL;
         }
 
         return list;

--- a/c/src/lang/lexer.c
+++ b/c/src/lang/lexer.c
@@ -107,6 +107,56 @@ struct lex_data find_alphanumeric_value (FILE* file, char *val){
 
         return ret;
 }
+/*
+match escape sequences to the chars they escape by editing val[0]
+return true if the lex is still valid
+*/
+bool lex_char_literal(FILE *file, char val[MAX_TOKEN_LENGTH + 1]){
+        if (val[0] != '\\'){
+                return true;
+        }
+
+        if (feof(file)){
+                return false;
+        }
+
+        switch(fgetc(file)){
+                case 'a':
+                        val[0] = '\a';
+                        break;
+                case 'b':
+                        val[0] = '\b';
+                        break;
+                case 'f':
+                        val[0] = '\f';
+                        break;
+                case 'n':
+                        val[0] = '\n';
+                        break;
+                case 'r':
+                        val[0] = '\r';
+                        break;
+                case 't':
+                        val[0] = '\t';
+                        break;
+                case 'v':
+                        val[0] = '\v';
+                        break;
+                case '\\':
+                        val[0] = '\\';
+                        break;
+                case '\'':
+                        val[0] = '\'';
+                        break;
+                case '\"':
+                        val[0] = '\"';
+                        break;
+                default:
+                        return false;
+        }
+
+        return true;
+}
 
 struct LIST(token)* lex(FILE *file){
         char val[MAX_TOKEN_LENGTH + 1];
@@ -127,6 +177,11 @@ struct LIST(token)* lex(FILE *file){
                 if (charlit_status == OPENED_CHARLIT){
                         data.type = SYMBOL_CHARLIT;
                         data.val_len = 1;
+                        if (!lex_char_literal(file, val)){
+                                free_list(list, free_token, token);
+                                free(list);
+                                return NULL;
+                        }
                 } else {
                         if (isspace(val[0])){
                                 val[0] = 0;

--- a/c/src/lang/lexer.c
+++ b/c/src/lang/lexer.c
@@ -81,8 +81,9 @@ struct lex_data find_alphanumeric_value (FILE* file, char *val){
                 --ret.val_len;
                 ret.excess = val[ret.val_len];                        
         }
-
-        if ((ret.val_len == 4) && (strncmp(val, "else", 4) == 0)){
+        if ((ret.val_len == 4) && (strncmp(val, "char", 4) == 0)){
+                ret.type = SYMBOL_CHAR;
+        } else if ((ret.val_len == 4) && (strncmp(val, "else", 4) == 0)){
                 ret.type = SYMBOL_ELSE;
         } else if ((ret.val_len == 3) && (strncmp(val, "for", 3) == 0)){
                 ret.type = SYMBOL_FOR;

--- a/c/src/lang/poppy_grammar.c
+++ b/c/src/lang/poppy_grammar.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define RULE_COUNT 65
+#define RULE_COUNT 67
 #define COMMA ,
 #define populate(lh_symbol, rh_symbols, ctr, grmr)                               \
         do {                                                                     \
@@ -43,6 +43,7 @@ const struct grammar * const get_poppy_grammar(){
         populate(SYMBOL_DEFN, {SYMBOL_TYPE COMMA SYMBOL_IDENTIFIER COMMA SYMBOL_LPAREN COMMA SYMBOL_OPTPARAMS COMMA SYMBOL_RPAREN COMMA SYMBOL_LBRACE COMMA SYMBOL_STMTS COMMA SYMBOL_RBRACE}, i, poppy_grammar); ++i;
         populate(SYMBOL_TYPE, {SYMBOL_INT}, i, poppy_grammar); ++i;
         populate(SYMBOL_TYPE, {SYMBOL_VOID}, i, poppy_grammar); ++i;
+        populate(SYMBOL_TYPE, {SYMBOL_CHAR}, i, poppy_grammar); ++i;
         populate(SYMBOL_OPTPARAMS, {}, i, poppy_grammar); ++i;
         populate(SYMBOL_OPTPARAMS, {SYMBOL_PARAMS}, i, poppy_grammar); ++i;
         populate(SYMBOL_PARAMS, {SYMBOL_PARAM COMMA SYMBOL_COMMA COMMA SYMBOL_PARAMS}, i, poppy_grammar); ++i;
@@ -97,6 +98,7 @@ const struct grammar * const get_poppy_grammar(){
         populate(SYMBOL_UNEXPR, {SYMBOL_DEC COMMA SYMBOL_IDENTIFIER}, i, poppy_grammar); ++i;
         populate(SYMBOL_UNEXPR, {SYMBOL_IDENTIFIER}, i, poppy_grammar); ++i;
         populate(SYMBOL_UNEXPR, {SYMBOL_CONSTANT}, i, poppy_grammar); ++i;
+        populate(SYMBOL_UNEXPR, {SYMBOL_SQUOTE COMMA SYMBOL_CHARLIT COMMA SYMBOL_SQUOTE}, i, poppy_grammar); ++i;
 
         for (size_t i = 0; i < RULE_COUNT; ++i){
                 if (poppy_grammar->rules[i].rhs_len == 0){

--- a/c/src/lang/type.c
+++ b/c/src/lang/type.c
@@ -12,6 +12,7 @@ bool initialized = false;
 struct type *int_ptr = NULL;
 struct type *void_ptr = NULL;
 struct type *bool_ptr = NULL;
+struct type *char_ptr = NULL;
 
 void add_type(struct type *new) {
         if (!initialized) {
@@ -50,6 +51,13 @@ const struct type* const void_type(){
                 void_ptr = simple_type("v", false, true);
         }
         return void_ptr;
+}
+
+const struct type* const char_type(){
+        if (char_ptr == NULL){
+                char_ptr = simple_type("c", true, true);
+        }
+        return char_ptr;
 }
 
 const struct type* const function_type(const struct type *ret, const struct type *params[MAX_PARAM_COUNT], size_t params_len){

--- a/c/src/lang/type.c
+++ b/c/src/lang/type.c
@@ -86,6 +86,8 @@ const struct type* const return_type(const struct type *type){
         switch (type->repr[0]){
                 case 'i':
                         return int_type();
+                case 'c':
+                        return char_type();
                 case 'v':
                         return void_type();
                 default:
@@ -108,6 +110,9 @@ bool equals_arg_types(const struct type *args[MAX_PARAM_COUNT], size_t args_len,
                 switch (type->repr[i + 2]){
                         case 'i':
                                 param_type = int_type();
+                                break;
+                        case 'c':
+                                param_type = char_type();
                                 break;
                         default:
                                 return false;

--- a/c/src/lang/type.c
+++ b/c/src/lang/type.c
@@ -4,6 +4,11 @@
 
 #include "data/list.h"
 
+#define INT_CHAR 'i'
+#define VOID_CHAR 'v'
+#define BOOL_CHAR 'b'
+#define CHAR_CHAR 'c'
+
 DEFINE_LIST(type);
 
 struct LIST(type) types;
@@ -23,9 +28,10 @@ void add_type(struct type *new) {
         append_list((&types), new, type);
 }
 
-struct type* simple_type(char *repr, bool assignable, bool returnable){
+struct type* simple_type(char repr, bool assignable, bool returnable){
         struct type* new = (struct type*) malloc(sizeof(struct type));
-        strcpy(new->repr, repr);
+        new->repr[0] = repr;
+        new->repr[1] = 0; 
         new->assignable = assignable;
         new->returnable = returnable;
         add_type(new);
@@ -34,28 +40,28 @@ struct type* simple_type(char *repr, bool assignable, bool returnable){
 
 const struct type* const int_type(){
         if (int_ptr == NULL){
-                int_ptr = simple_type("i", true, true);
+                int_ptr = simple_type(INT_CHAR, true, true);
         }
         return int_ptr;
 }
 
 const struct type* const bool_type(){
         if (bool_ptr == NULL){
-                bool_ptr = simple_type("b", false, false);
+                bool_ptr = simple_type(BOOL_CHAR, false, false);
         }
         return bool_ptr;
 }
 
 const struct type* const void_type(){
         if (void_ptr == NULL){
-                void_ptr = simple_type("v", false, true);
+                void_ptr = simple_type(VOID_CHAR, false, true);
         }
         return void_ptr;
 }
 
 const struct type* const char_type(){
         if (char_ptr == NULL){
-                char_ptr = simple_type("c", true, true);
+                char_ptr = simple_type(CHAR_CHAR, true, true);
         }
         return char_ptr;
 }
@@ -84,11 +90,11 @@ const struct type* const function_type(const struct type *ret, const struct type
 
 const struct type* const return_type(const struct type *type){
         switch (type->repr[0]){
-                case 'i':
+                case INT_CHAR:
                         return int_type();
-                case 'c':
+                case CHAR_CHAR:
                         return char_type();
-                case 'v':
+                case VOID_CHAR:
                         return void_type();
                 default:
                         return NULL;
@@ -108,10 +114,10 @@ bool equals_arg_types(const struct type *args[MAX_PARAM_COUNT], size_t args_len,
         for (size_t i = 0; i < args_len; ++i){
                 const struct type *param_type;
                 switch (type->repr[i + 2]){
-                        case 'i':
+                        case INT_CHAR:
                                 param_type = int_type();
                                 break;
-                        case 'c':
+                        case CHAR_CHAR:
                                 param_type = char_type();
                                 break;
                         default:

--- a/c/src/main.c
+++ b/c/src/main.c
@@ -42,6 +42,8 @@ int main(int argc, char *argv[]){
                 return 0;
         }
 
+        printf("lexed\n");
+
         const struct grammar *poppy_grammar = get_poppy_grammar();
         const struct parse_tree *pt = parse(poppy_grammar, list);
         free_poppy_grammar();
@@ -51,6 +53,8 @@ int main(int argc, char *argv[]){
                 free(list);
                 return 0;
         }
+
+        printf("parsed\n");
 
         const struct OUTER_TYPE_MAP *types = find_types(pt);
         if (types != NULL){

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -19,6 +19,7 @@ $$\begin{align*}
 \text{defn} &\rightarrow \text{type IDENTIFIER LPAREN optparams RPAREN LBRACE stmts RBRACE}\\
 \text{type} &\rightarrow \text{INT}\\
 \text{type} &\rightarrow \text{VOID}\\
+\text{type} &\rightarrow \text{CHAR}\\
 \text{optparams} &\rightarrow \varnothing \\
 \text{optparams} &\rightarrow \text{params} \\
 \text{params} &\rightarrow \text{param COMMA params}  \\
@@ -73,5 +74,6 @@ $$\begin{align*}
 \text{unexpr} &\rightarrow \text{DEC IDENTIFIER} \\
 \text{unexpr} &\rightarrow \text{IDENTIFIER}  \\
 \text{unexpr} &\rightarrow \text{CONSTANT}  \\
+\text{unexpr} &\rightarrow \text{SQUOTE CHARLIT SQUOTE}
 \end{align*}
 $$

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -4,10 +4,11 @@ _token_:
 - _keyword_
 - _identifier_
 - _constant_
+- _charlit_
 - _punctuator_
 
 _keyword_:
-- One of __else__, __for__, __hop__, __if__, __int__, __let__, __munch__, __void__, __while__
+- One of __char__, __else__, __for__, __hop__, __if__, __int__, __let__, __munch__, __void__, __while__
 
 _identifier_:
 - any string matching the following regex that is not part of the above list: [A-Za-z_][A-Za-z0-9_]*
@@ -15,5 +16,8 @@ _identifier_:
 _constant_:
 - any string matching the following regex: [1-9][0-9]*
 
+_charlit_:
+- any single character
+
 _punctuator_:
-- One of __(__, __)__, __{__, __}__, __++__, __--__, __&&__, __||__, __!__, __+__, __-__, __*__, __/__, __%__, __<__, __>__, __<=__, __>=__, __==__, __!=__, __=__, __,__, __;__
+- One of __(__, __)__, __{__, __}__, __++__, __--__, __&&__, __||__, __!__, __+__, __-__, __*__, __/__, __%__, __<__, __>__, __<=__, __>=__, __==__, __!=__, __=__, __,__, __;__, __'__

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -5,6 +5,7 @@ $$
 \begin{align*}
 \text{type}&\rightarrow \text{returnabletype}\\
 \text{returnabletype}&\rightarrow \text{int}\\
+\text{returnabletype}&\rightarrow \text{char}\\
 \text{returnabletype}&\rightarrow \text{void}\\
 \text{type}&\rightarrow \text{bool}\\
 \text{type}&\rightarrow \text{(optparams) $\mapsto$ returnabletype}\\
@@ -12,6 +13,7 @@ $$
 \text{optparams}&\rightarrow \text{params}\\
 \text{params}&\rightarrow \text{param, params}\\
 \text{param}&\rightarrow \text{int}\\
+\text{param}&\rightarrow \text{char}\\
 \end{align*}
 $$
 
@@ -58,11 +60,11 @@ $$\frac{\Gamma \vdash b: \text{bool} \quad \Gamma \vdash E: \tau}{\Gamma \vdash 
 $$\frac{\Gamma \vdash b: \text{bool} \quad \Gamma \vdash a, c : \text{void}\quad \Gamma \vdash E: \tau}{\Gamma \vdash \text{for }(a;b;c)\{E\}: \tau}$$
 
 ## Predicates
-$$\frac{\Gamma \vdash E_1:\tau \quad \Gamma \vdash E_2:\tau}{
+$$\frac{\Gamma \vdash E_1:\tau \quad \Gamma \vdash E_2:\tau\quad \tau \in \{\text{int, char}\}}{
     \Gamma \vdash E_1 == E_2 : \text{bool} \quad \Gamma \vdash E_1 \text{ != } E_2 : \text{bool}
 }$$
 
-$$\frac{\Gamma \vdash E_1:\text{int} \quad \Gamma \vdash E_2:\text{int}}{
+$$\frac{\Gamma \vdash E_1:\tau \quad \Gamma \vdash E_2:\tau \quad \tau \in \{\text{int, char}\}}{
     \Gamma \vdash E_1 < E_2 : \text{bool} \quad \Gamma \vdash E_1 > E_2 : \text{bool} \quad
     \Gamma \vdash E_1 <= E_2 : \text{bool} \quad \Gamma \vdash E_1 >= E_2 : \text{bool}
 }$$
@@ -77,14 +79,15 @@ $$\frac{\Gamma \vdash E_1 : \text{bool} \quad \Gamma \vdash E_2 : \text{bool}}{
 }$$
 
 ## Arithmetic
-$$\frac{\Gamma \vdash E_1: \text{int}\quad \Gamma \vdash E_2: \text{int}}{
-    \Gamma \vdash E_1 + E_2 : \text{int} \quad \Gamma \vdash E_1 - E_2 : \text{int} \quad \Gamma \vdash E_1 * E_2 : \text{int} \quad \Gamma \vdash E_1 \text{ / }E_2 : \text{int} \quad \Gamma \vdash E_1 
-    \text{ \% } E_2 : \text{int}
+$$\frac{\Gamma \vdash E_1: \tau_1\quad \Gamma \vdash E_2: \tau_2\quad \tau_1,\tau_2 \in \{\text{int, char}\}}{
+    \Gamma \vdash E_1 + E_2 : \tau_1 \quad \Gamma \vdash E_1 - E_2 : \tau_1 \quad \Gamma \vdash E_1 * E_2 : \tau_1 \quad \Gamma \vdash E_1 \text{ / }E_2 : \tau_1 \quad \Gamma \vdash E_1 
+    \text{ \% } E_2 : \tau_1
 }$$
 
-$$\frac{\Gamma \vdash E: \tau}{\Gamma \vdash (E):\tau}$$
+$$\frac{\Gamma \vdash E: \tau \quad \tau \in \{\text{int, char}\}}{\Gamma \vdash (E):\tau}$$
 
 
 ## Literals
 
 $$\Gamma \vdash \text{CONSTANT}: \text{int}$$
+$$\Gamma \vdash \text{SQUOTE CHARLIT SQUOTE}: \text{char}$$


### PR DESCRIPTION
This PR implements a `char` data type, which can now be used for variables, parameters, and return types. See the below program as an example:
```
munch poppyio

char digit_to_char(int digit){
    hop '0' + num;
}

void main(){
    printc(num_to_char(3));
}
```

Note the use of the `printc` builtin to print the value of `num_to_char(3)`.

As an aside, when an `int` and a `char` are operands of an operation, the type of the result is the type of the first operand. This may change in the future as we introduce more data types with different precisions.